### PR TITLE
Added support for SCEPDispositionPending and added Get-NDESCACertificate

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,12 @@
 ﻿== Changelog PSCertificateEnrollment PowerShell Module
 
+=== 1.0.10 (Nov 2, 2023)
+
+* `Get-NDESCertificate` now supports waiting for certificate requests needing administrator approval for issuing.
+* `Get-NDESCertificate` now cleans up the create Private Key, if the NDES server returns an error, to avoid dangling private keys.
+* `Get-NDESOTP` seems to use NTLM for authentication, at least in a default setup of the NDES server, so user notification states this.
+* `Get-NDESCACertificate` new. Supports downloading CA certificates from the NDES server, written to file, importing into Trusted Auth Root container, or both.
+
 === 1.0.9 (May 30, 2023)
 
 * `Get-IssuedCertificate` supports the UniformResourceIdentifier SAN type now.

--- a/Functions/Get-NDESCACertificate.ps1
+++ b/Functions/Get-NDESCACertificate.ps1
@@ -1,0 +1,172 @@
+﻿<#
+    .SYNOPSIS
+    Requests a Certificate from an NDES Server via the SCEP Protocol.
+    This works on Windows 8.1 and newer Operating Systems.
+
+    .PARAMETER ComputerName
+    Specifies the Host Name or IP Address of the NDES Server.
+    If using SSL, this must match the NDES Server's identity as specified in its SSL Server Certificate.
+
+    .PARAMETER UseSSL
+    Forces the connection to use SSL Encryption. Not necessary from a security perspective,
+    as the SCEP Message's confidential partsd are encrypted with the NDES RA Certificates anyway.
+
+    .PARAMETER Port
+    Specifies the Network Port of the NDES Server to be used.
+    Only necessary if your NDES Server is running on a non-default Port for some reason.
+    Defaults to Port 80 without SSL and 443 with SSL.
+
+    .PARAMETER CertificateFolder
+    Path of folder where CA certifcates are written. Defaults to current directory. 
+    Filenames will be CA-cert-<i>.crt, where i is a number from 0 to n.
+    Only used when exporting to files.
+
+    .PARAMETER Export
+    Export CA certificates to files. 
+    Import, Export or both must be specified.
+
+    .PARAMETER Import
+    Import the CA certificates into the computer Trusted Root Certification Authorities.
+    Import, Export or both must be specified.
+
+    .OUTPUTS
+    System.Security.Cryptography.X509Certificates.X509Certificate. Returns the CA Certificate returned by the NDES Server.
+#>
+Function Get-NDESCACertificate {
+
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory=$True)]
+        [String]
+        $ComputerName,
+
+        [Alias("SSL")]
+        [Parameter(Mandatory=$False)]
+        [Switch]
+        $UseSSL = $False,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateRange(1,65535)]
+        [Int]
+        $Port,
+
+        [Parameter(Mandatory=$False)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Suffix = "certsrv/mscep/mscep.dll",
+
+        [Parameter(Mandatory=$False)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $CertificateFolder = $(Get-Location),
+
+        [Parameter(Mandatory=$False)]
+        [Switch]
+        $Import = $False,
+
+        [Parameter(Mandatory=$False)]
+        [Switch]
+        $Export = $False
+
+    )
+
+    begin  {
+
+        If (-not ($Import.IsPresent -or $Export.IsPresent)) {
+          throw 'Missing switch. Import, Export or both must be specified.'
+        }
+    
+        Add-Type -AssemblyName System.Security
+
+        # This hides the Status Indicators of the Invoke-WebRequest Calls later on
+        $ProgressPreference = 'SilentlyContinue'
+
+        # Assembling the Configuration String, which is the SCEP URL in this Case
+        If ($UseSSL)
+            { $Protocol = "https" }
+        Else 
+            { $Protocol = "http" }
+
+        If ($Port)
+            { $PortString = ":$($Port)" }
+        Else
+            { $PortString = [String]::Empty }
+
+        $ConfigString = "$($Protocol)://$($ComputerName)$($PortString)/$($Suffix)/pkiclient.exe"
+
+        Write-Verbose -Message "Configuration String: $ConfigString"
+
+        # SCEP GetCACert Operation
+        Try {
+            $GetCACert = (Invoke-WebRequest -uri "$($ConfigString)?operation=GetCACert").Content
+
+            # Decoding the CMS (PKCS#7 Message that was returned from the NDES Server)
+            $Pkcs7CaCert = New-Object System.Security.Cryptography.Pkcs.SignedCms
+            $Pkcs7CaCert.Decode($GetCACert)
+        }
+        Catch {
+            Write-Error -Message $PSItem.Exception.Message
+            return
+        }
+
+    }
+
+    process {
+        # Ensuring we work with Elevation when messing with the Computer Certificate Store
+        If ($Import.IsPresent) {
+            
+            If (-not (
+                [Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
+                ).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+                Write-Error -Message "This must be run with Elevation (Run as Administrator) since using the Machine Context!" 
+                return
+            }
+        }
+
+        # Skip pipeline processing if the preparation steps failed
+        If (-not $Pkcs7CaCert.Certificates) { return }
+
+        <#
+            Identify the Root CA Certificate that was delivered with the Chain
+            https://tools.ietf.org/html/rfc5280#section-6.1
+            A certificate is self-issued if the same DN appears in the subject and issuer fields 
+        #>
+        $RootCaCert = $Pkcs7CaCert.Certificates | Where-Object { $_.Subject -eq $_.Issuer }
+
+        $certnum = 0
+
+        Try {
+            If ($Import.IsPresent) {
+                $X509Store = New-Object System.Security.Cryptography.X509Certificates.X509Store -ArgumentList ("AuthRoot", [System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine)
+                $X509Store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::OpenExistingOnly -bor [System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+            }
+
+            $CertificateRequestAgentOid = New-Object Security.Cryptography.Oid "1.3.6.1.4.1.311.20.2.1" # Certificate Request Agent
+            $Pkcs7CaCert.Certificates | Where-Object { 
+                $isRA = $_.EnhancedKeyUsageList | Where ObjectId -eq $CertificateRequestAgentOid.Value 
+                If (-not $isRA) {
+                    return $True
+                }
+            } | ForEach-Object { 
+                If ($Export.IsPresent) {
+                    $outputPath = "$($CertificateFolder)\CA-cert-$($certnum).crt" 
+                    $base64CertText = [System.Convert]::ToBase64String($_.RawData, "InsertLineBreaks")
+                    $out = "-----BEGIN CERTIFICATE-----`n$($base64CertText)`n-----END CERTIFICATE-----"
+                    [System.IO.File]::WriteAllText($outputPath, $out)
+                    Write-Output "$($_.Subject) written to $($outputPath)"
+                }
+                If ($Import.IsPresent) {
+                    $X509Store.Add($_)
+                    Write-Output "$($_.Subject) imported to Cert:$($X509Store.Location)\$($X509Store.Name)"
+                }
+            }
+
+        }
+        Catch {
+            Write-Error -Message $PSItem.Exception.Message
+            return
+        }
+    }
+
+    end {}
+}

--- a/Functions/Get-NDESOTP.ps1
+++ b/Functions/Get-NDESOTP.ps1
@@ -52,7 +52,7 @@ Function Get-NDESOTP {
     begin {
 
         If ($NoSSL) { 
-            Write-Warning "Not using SSL. Authentication Credentials will be sent in Cleartext"
+            Write-Warning "Not using SSL. Authentication Credentials might be sent in Cleartext, but usually using NTLM"
             $Protocol = "http" 
         }
         Else {

--- a/PSCertificateEnrollment.psd1
+++ b/PSCertificateEnrollment.psd1
@@ -12,7 +12,7 @@
     RootModule = 'PSCertificateEnrollment.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.9'
+    ModuleVersion = '1.0.10'
 
     # Supported PSEditions.
     # https://docs.microsoft.com/en-us/powershell/scripting/gallery/concepts/module-psedition-support

--- a/PSCertificateEnrollment.psd1
+++ b/PSCertificateEnrollment.psd1
@@ -73,6 +73,7 @@
     FunctionsToExport = @(
         'Get-NDESOTP',
         'Get-NDESCertificate',
+        'Get-NDESCACertificate',
         'Get-KeyStorageProvider',
         'Get-IssuedCertificate',
         'New-CertificateRequest',

--- a/PSCertificateEnrollment.psm1
+++ b/PSCertificateEnrollment.psm1
@@ -423,6 +423,7 @@ $ModuleRoot = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 # Import Public Functions
 . $ModuleRoot\Functions\Get-NDESOTP.ps1
 . $ModuleRoot\Functions\Get-NDESCertificate.ps1
+. $ModuleRoot\Functions\Get-NDESCACertificate.ps1
 . $ModuleRoot\Functions\Get-KeyStorageProvider.ps1
 . $ModuleRoot\Functions\Get-IssuedCertificate.ps1
 . $ModuleRoot\Functions\New-CertificateRequest.ps1

--- a/README.adoc
+++ b/README.adoc
@@ -33,6 +33,7 @@ The following Commands are available:
 
 * `Get-NDESOTP` 
 * `Get-NDESCertificate` 
+* `Get-NDESCACertificate` 
 * `Get-IssuedCertificate` 
 * `New-CertificateRequest` 
 * `New-SignedCertificateRequest` 
@@ -46,7 +47,7 @@ The following Commands are available:
 
 `Get-NDESOTP` retrieves an One-Time-Password (OTP) from the NDES Server.
 
-Uses SSL by default. SSL can be disabled if required, but this is not recommended.
+Uses SSL by default. SSL can be disabled if required, but this is not recommended. Seems to use NTLM authentication in default NDES-server setup.
 
 Uses your Windows Identity by default but can also be passed a PSCredential Object (Get-Credential).
 
@@ -59,6 +60,30 @@ Example: Retrieving a NDES One-Time Password
 Get-NDESOTP `
 -ComputerName 'ndes01.intra.adcslabor.de' `
 -Credential $(Get-Credential)
+----
+
+==== Get-NDESCACertificate
+
+`Get-NDESCACertificate` retrieves the CA certificate(s) from the NDES Server.
+
+The certificates may be written to file, imported into Trusted Root Certification Authorities or both.
+
+Example: Retrieving and exporting CA certificates
+
+[source,powershell]
+----
+Get-NDESCACertificate `
+-ComputerName 'ndes01.intra.adcslabor.de' `
+-Export -CertificateFolder C:\NDES-CA
+----
+
+Example: Retrieving and importing CA certificates
+
+[source,powershell]
+----
+Get-NDESCACertificate `
+-ComputerName 'ndes01.intra.adcslabor.de' `
+-Import
 ----
 
 ==== Get-NDESCertificate


### PR DESCRIPTION
Get-NDESOTP:
Changed notification to include information about NTLM, since it seems to be the authentication method used. Confirmed using Wireshark.

Added Get-NDESCACertificate, capable of downloading CA certificates from the NDES server, and optionally importing them into Trusted Auth Root container.

Get-NDESCertificate:
Added support for SCEPDispositionPending, by waiting and retrying retrieval of the certificate.
Added printing of TransactionId, since if not waiting for approval, an enrollment might be completed using certreq.exe when the TransactionId is known.
If enrollment fails on the NDES server, the locally created Private Key is deleted, to avoid having dangling Private Keys. Especially important when using hardware stores for keys, like the TPM.