### PR TITLE
Adjusts behavior of -Suffix parameter in Get-SCEPCertificate.ps1

### DIFF
--- a/Functions/Get-SCEPCertificate.ps1
+++ b/Functions/Get-SCEPCertificate.ps1
@@ -232,7 +232,7 @@ Function Get-SCEPCertificate {
 
  	if ($Suffix) {
   	    $ConfigString = $ConfigString + "/" + $Suffix
-
+	}
         Write-Verbose -Message "Configuration String: $ConfigString"
 
         # SCEP GetCACaps Operation


### PR DESCRIPTION
Modifies Get-SCEPCertificate.ps1 to adjust the behavior of the -Suffix parameter. The previous behavior forced the configuration string to always end with `/pkiclient.exe` which is a standard endpoint but is not always implemented appropriately by certificate issuers - as an example, when performing SCEP enrollment with Okta as the Certificate Authority, their certificate endpoints never end with this suffix.

Now, the -Suffix parameter may optionally specified as an empty string, which will result in nothing being appended to the configuration string after the port number. Situations where -Suffix is not specified have identical behavior as the `/pkiclient.exe` addendum is part of the default parameter value.

In production deployments, this change will require adjustments to invocations of `Get-SCEPCertificate` where the -Suffix parameter is provided. Users will need to ensure that the `/pkiclient.exe` addendum is included in their specified -Suffix parameter; previously this inclusion was not necessary as it was hardcoded. 